### PR TITLE
fix: bump gbif-occurrence to 1.1.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <kvs.version>3.0</kvs.version>
     <hbase-utils.version>1.0.0</hbase-utils.version>
     <gbif-wrangler.version>1.0.0</gbif-wrangler.version>
-    <gbif-occurrence.version>1.1.19</gbif-occurrence.version>
+    <gbif-occurrence.version>1.1.24</gbif-occurrence.version>
     <vocabulary-lookup.version>2.0.3</vocabulary-lookup.version>
     <registry.version>4.2.8</registry.version>
     <gbif-common-ws.version>2.1.1</gbif-common-ws.version>


### PR DESCRIPTION
1.1.19 was pruned from repository.gbif.org releases (only >= 1.1.24 remain), breaking our build.